### PR TITLE
修复两个bug：签名计算错误和xml解析错误

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "homer/wxpay",
+  "name": "aplum/wxpay",
   "version": "1.0.0",
   "description": "wxpay support",
   "license": "proprietary",
@@ -10,7 +10,7 @@
       "src/Support/helpers.php"
     ],
     "psr-4": {
-      "Homer\\Payment\\Wxpay\\": "src/"
+      "Aplum\\Payment\\Wxpay\\": "src/"
     }
   },
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "aplum/wxpay",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "wxpay support",
   "license": "proprietary",
   "type": "library",

--- a/phpspec.yml
+++ b/phpspec.yml
@@ -1,5 +1,5 @@
 suites:
     main:
-        namespace: Homer\Payment\Wxpay
-        psr4_prefix: Homer\Payment\Wxpay
+        namespace: Aplum\Payment\Wxpay
+        psr4_prefix: Aplum\Payment\Wxpay
         src_path: src

--- a/spec/JsServiceSpec.php
+++ b/spec/JsServiceSpec.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace spec\Homer\Payment\Wxpay;
+namespace spec\Aplum\Payment\Wxpay;
 
 use Carbon\Carbon;
 use GuzzleHttp\RequestOptions;
@@ -21,7 +21,7 @@ class JsServiceSpec extends ObjectBehavior
             'notify_url' => 'http://localhost/trade.php',
         ];
 
-        $this->beAnInstanceOf(\Homer\Payment\Wxpay\JsService::class, [$config, $client]);
+        $this->beAnInstanceOf(\Aplum\Payment\Wxpay\JsService::class, [$config, $client]);
     }
 
     function letGo()

--- a/spec/ServiceSpec.php
+++ b/spec/ServiceSpec.php
@@ -1,5 +1,5 @@
 <?php
-namespace spec\Homer\Payment\Wxpay;
+namespace spec\Aplum\Payment\Wxpay;
 
 use Carbon\Carbon;
 use GuzzleHttp\RequestOptions;
@@ -20,7 +20,7 @@ class ServiceSpec extends ObjectBehavior
             'notify_url' => 'http://localhost/trade.php',
         ];
 
-        $this->beAnInstanceOf(\Homer\Payment\Wxpay\Service::class, [$config, $client]);
+        $this->beAnInstanceOf(\Aplum\Payment\Wxpay\Service::class, [$config, $client]);
     }
 
     //=========================================

--- a/src/AbstractService.php
+++ b/src/AbstractService.php
@@ -389,7 +389,7 @@ abstract class AbstractService
             throw new \Exception('bad response from wxpay: ' . (string)$response->getBody());
         }
 
-        $xml = simplexml_load_string((string) $response->getBody());
+        $xml = simplexml_load_string((string) $response->getBody(), 'SimpleXMLElement', LIBXML_NOCDATA);
         if (empty($xml->return_code)) {
             throw new \Exception('bad response from wxpay: ' . (string)$response->getBody());
         }
@@ -477,7 +477,9 @@ abstract class AbstractService
     {
         $imploded = '';
         foreach ($assoc as $name => $value) {
-            $imploded .=  $name . $inGlue . $value . $outGlue;
+            if ($name != "sign" && $value != "" && !is_array($value)) {
+                $imploded .=  $name . $inGlue . $value . $outGlue;
+            }
         }
 
         return substr($imploded, 0, -strlen($outGlue));

--- a/src/AbstractService.php
+++ b/src/AbstractService.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Homer\Payment\Wxpay;
+namespace Aplum\Payment\Wxpay;
 
 
 use Carbon\Carbon;
@@ -14,6 +14,14 @@ abstract class AbstractService
     const ORDER_QUERY_URL   = 'https://api.mch.weixin.qq.com/pay/orderquery';
     const REFUND_URL        = 'https://api.mch.weixin.qq.com/secapi/pay/refund';
     const REFUND_QUERY_URL  = 'https://api.mch.weixin.qq.com/pay/refundquery';
+
+    /*
+    // 测试环境
+    const UNIFIED_ORDER_URL = 'https://api.mch.weixin.qq.com/sandbox/pay/unifiedorder';
+    const ORDER_QUERY_URL   = 'https://api.mch.weixin.qq.com/sandbox/pay/orderquery';
+    const REFUND_URL        = 'https://api.mch.weixin.qq.com/sandbox/secapi/pay/refund';
+    const REFUND_QUERY_URL  = 'https://api.mch.weixin.qq.com/sandbox/pay/refundquery';
+    */
 
     // default trade state
     const DEFAULT_TRADE_STATE    = 'UNKNOWN';

--- a/src/JsService.php
+++ b/src/JsService.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Homer\Payment\Wxpay;
+namespace Aplum\Payment\Wxpay;
 
 use Carbon\Carbon;
 

--- a/src/Service.php
+++ b/src/Service.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Homer\Payment\Wxpay;
+namespace Aplum\Payment\Wxpay;
 
 use Carbon\Carbon;
 

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -38,7 +38,7 @@ if (!function_exists('xml_to_array')) {
     function xml_to_array($xml)
     {
         if (is_string($xml)) {
-            $xml = simplexml_load_string($xml);
+            $xml = simplexml_load_string($xml, 'SimpleXMLElement', LIBXML_NOCDATA);
         }
 
         return array_map('trim', (array)$xml);


### PR DESCRIPTION
1. 计算签名时，应该舍弃没有值的项。例如 attach 字段，如果商家没有传值，则不应该计算签名
2. xml解析，应该增加LIBXML_NOCDATA参数，避免解析错误
